### PR TITLE
Refactor to use get_option instead of get_network_option

### DIFF
--- a/admin/class-leira-letter-avatar-admin.php
+++ b/admin/class-leira-letter-avatar-admin.php
@@ -164,7 +164,7 @@ class Leira_Letter_Avatar_Admin{
 	public function admin_body_class( $classes ) {
 		if ( leira_letter_avatar()->is_active() ) {
 			$classes .= ' leira_letter_avatar';
-			if ( get_network_option( null, 'leira_letter_avatar_rounded', true ) ) {
+			if ( get_option( 'leira_letter_avatar_rounded', true ) ) {
 				$classes .= ' leira_letter_avatar_rounded';
 			}
 		}
@@ -472,7 +472,7 @@ class Leira_Letter_Avatar_Admin{
 	 */
 	public function render_active_settings() {
 
-		$option = get_network_option( null, 'avatar_default', 'mystery' );
+		$option = get_option( 'avatar_default', 'mystery' );
 		$option = $this->sanitize->avatar_default( $option );
 		?>
 		<label for="settings_avatar_default">
@@ -491,7 +491,7 @@ class Leira_Letter_Avatar_Admin{
 	 */
 	public function render_gravatar_settings() {
 
-		$gravatar = get_network_option( null, 'leira_letter_avatar_gravatar', false );
+		$gravatar = get_option( 'leira_letter_avatar_gravatar', false );
 		$gravatar = $this->sanitize->boolean( $gravatar );
 		?>
 		<label for="settings_gravatar">
@@ -510,7 +510,7 @@ class Leira_Letter_Avatar_Admin{
 	 */
 	public function render_format_settings() {
 
-		$format = get_network_option( null, 'leira_letter_avatar_format', 'svg' );
+		$format = get_option( 'leira_letter_avatar_format', 'svg' );
 		$format = $this->sanitize->format( $format );
 		?>
 		<label for="settings_format">
@@ -533,7 +533,7 @@ class Leira_Letter_Avatar_Admin{
 	 * @since 1.0.0
 	 */
 	public function render_shape_settings() {
-		$rounded = get_network_option( null, 'leira_letter_avatar_rounded', true );
+		$rounded = get_option( 'leira_letter_avatar_rounded', true );
 		$rounded = $this->sanitize->boolean( $rounded );
 		?>
 		<fieldset>
@@ -561,13 +561,13 @@ class Leira_Letter_Avatar_Admin{
 	 * @since 1.0.0
 	 */
 	public function render_letters_settings() {
-		$letters = get_network_option( null, 'leira_letter_avatar_letters', 2 );
+		$letters = get_option( 'leira_letter_avatar_letters', 2 );
 		$letters = $this->sanitize->letters( $letters );
 
-		$bold = get_network_option( null, 'leira_letter_avatar_bold', false );
+		$bold = get_option( 'leira_letter_avatar_bold', false );
 		$bold = $this->sanitize->boolean( $bold );
 
-		$uppercase = get_network_option( null, 'leira_letter_avatar_uppercase', true );
+		$uppercase = get_option( 'leira_letter_avatar_uppercase', true );
 		$uppercase = $this->sanitize->boolean( $uppercase );
 		?>
 		<fieldset>
@@ -617,10 +617,10 @@ class Leira_Letter_Avatar_Admin{
 	 * @since 1.2.2
 	 */
 	public function render_color_settings() {
-		$color_method = get_network_option( null, 'leira_letter_avatar_color_method', 'auto' );
+		$color_method = get_option( 'leira_letter_avatar_color_method', 'auto' );
 		$color_method = $this->sanitize->color_method( $color_method );
 
-		$color = get_network_option( null, 'leira_letter_avatar_color', 'ffffff' );
+		$color = get_option( 'leira_letter_avatar_color', 'ffffff' );
 		$color = $this->sanitize->background( $color );
 		?>
 		<fieldset>
@@ -665,13 +665,13 @@ class Leira_Letter_Avatar_Admin{
 	 * @since 1.0.0
 	 */
 	public function render_background_settings() {
-		$method = get_network_option( null, 'leira_letter_avatar_method' );
+		$method = get_option( 'leira_letter_avatar_method' );
 		$method = $this->sanitize->method( $method );
 
-		$bg = get_network_option( null, 'leira_letter_avatar_bg', 'fc91ad' );
+		$bg = get_option( 'leira_letter_avatar_bg', 'fc91ad' );
 		$bg = $this->sanitize->background( $bg );
 
-		$bgs = get_network_option( null, 'leira_letter_avatar_bgs', '' );
+		$bgs = get_option( 'leira_letter_avatar_bgs', '' );
 		$bgs = $this->sanitize->backgrounds( $bgs );
 		?>
 		<fieldset>
@@ -740,7 +740,7 @@ class Leira_Letter_Avatar_Admin{
 
 		if ( isset( $current_screen->id ) && in_array( $current_screen->id, $pages ) ) {
 			// Change the footer text
-			if ( ! get_network_option( null, 'leira_letter_avatar_footer_rated' ) ) {
+			if ( ! get_option( 'leira_letter_avatar_footer_rated' ) ) {
 
 				ob_start(); ?>
 				<a href="https://wordpress.org/support/plugin/leira-letter-avatar/reviews/?filter=5" target="_blank"
@@ -779,7 +779,7 @@ class Leira_Letter_Avatar_Admin{
 			wp_send_json_error( __( 'Please login as administrator', 'leira-letter-avatar' ) );
 		}
 
-		update_network_option( null, 'leira_letter_avatar_footer_rated', 1 );
+		update_option( 'leira_letter_avatar_footer_rated', 1 );
 		wp_send_json_success();
 	}
 

--- a/includes/class-leira-letter-avatar-deactivator.php
+++ b/includes/class-leira-letter-avatar-deactivator.php
@@ -37,8 +37,8 @@ class Leira_Letter_Avatar_Deactivator{
 		 *
 		 * @since 1.3.1
 		 */
-		if ( get_network_option( null, 'avatar_default' ) == 'leira_letter_avatar' ) {
-			update_network_option( null, 'avatar_default', 'mystery' );
+		if ( get_option( 'avatar_default' ) == 'leira_letter_avatar' ) {
+			update_option( 'avatar_default', 'mystery' );
 		}
 	}
 

--- a/includes/class-leira-letter-avatar.php
+++ b/includes/class-leira-letter-avatar.php
@@ -342,7 +342,7 @@ class Leira_Letter_Avatar{
 	 * @return bool
 	 */
 	public function is_active() {
-		$option = get_network_option( null, 'avatar_default', 'mystery' );
+		$option = get_option( 'avatar_default', 'mystery' );
 
 		return $option === 'leira_letter_avatar';
 	}

--- a/public/class-leira-letter-avatar-public.php
+++ b/public/class-leira-letter-avatar-public.php
@@ -258,8 +258,8 @@ class Leira_Letter_Avatar_Public{
 		}
 		$args = array_merge( array(
 			'size'     => 300,
-			'gravatar' => get_network_option( null, 'leira_letter_avatar_gravatar', false ),
-			'rating'   => get_network_option( null, 'avatar_rating', 'G' )
+			'gravatar' => get_option( 'leira_letter_avatar_gravatar', false ),
+			'rating'   => get_option( 'avatar_rating', 'G' )
 		), $args );
 
 		$size       = $args['size'];
@@ -368,12 +368,12 @@ class Leira_Letter_Avatar_Public{
 		}
 
 		$regex         = '/([^\pL]*(\pL)\pL*)/u';// \pL => matches any kind of letter from any language
-		$letters_count = get_network_option( null, 'leira_letter_avatar_letters', 2 );
+		$letters_count = get_option( 'leira_letter_avatar_letters', 2 );
 		$letters_count = $this->sanitize->letters( $letters_count );
 		$letters       = preg_replace( $regex, "$2", $letters );           //get all initials in the string
 		$letters       = mb_substr( $letters, 0, $letters_count, 'UTF-8' );//reduce to 2 or fewer initials
 
-		if ( get_network_option( null, 'leira_letter_avatar_uppercase', true ) ) {
+		if ( get_option( 'leira_letter_avatar_uppercase', true ) ) {
 			/**
 			 * Use mb_strtoupper in case initials contain letters with accents
 			 */
@@ -413,12 +413,12 @@ class Leira_Letter_Avatar_Public{
 			'font-size'  => $size * $font_ratio,
 			//'length'     => '', //image text length already set
 			'name'       => $letters,
-			'rounded'    => get_network_option( null, 'leira_letter_avatar_rounded', true ),
+			'rounded'    => get_option( 'leira_letter_avatar_rounded', true ),
 			'background' => $bg,
-			'bold'       => get_network_option( null, 'leira_letter_avatar_bold', false ),
+			'bold'       => get_option( 'leira_letter_avatar_bold', false ),
 			//'uppercase'  => '', //already set
 			'color'      => $color,
-			'format'     => get_network_option( null, 'leira_letter_avatar_format', 'svg' )
+			'format'     => get_option( 'leira_letter_avatar_format', 'svg' )
 		);
 
 		$url_args = apply_filters( 'leira_letter_avatar_url_args', $url_args, $id_or_email );
@@ -714,7 +714,7 @@ class Leira_Letter_Avatar_Public{
 		/**
 		 * Determine avatar url parameters base on user and email hash
 		 */
-		$current_option = get_network_option( null, 'leira_letter_avatar_method', 'auto' );
+		$current_option = get_option( 'leira_letter_avatar_method', 'auto' );
 		$current_option = $this->sanitize->method( $current_option );
 
 		/**
@@ -722,11 +722,11 @@ class Leira_Letter_Avatar_Public{
 		 */
 		switch ( $current_option ) {
 			case  'fixed':
-				$bg = get_network_option( null, 'leira_letter_avatar_bg' );
+				$bg = get_option( 'leira_letter_avatar_bg' );
 				$bg = $this->sanitize->background( $bg );
 				break;
 			case 'random':
-				$backgrounds = get_network_option( null, 'leira_letter_avatar_bgs', 'fc91ad' );
+				$backgrounds = get_option( 'leira_letter_avatar_bgs', 'fc91ad' );
 				$backgrounds = $this->sanitize->backgrounds( $backgrounds );
 				$backgrounds = explode( ',', $backgrounds );
 				if ( empty( $backgrounds ) ) {
@@ -775,12 +775,12 @@ class Leira_Letter_Avatar_Public{
 	 * @since 1.3.11
 	 */
 	protected function get_avatar_color( string $bg ): string {
-		$color_method = get_network_option( null, 'leira_letter_avatar_color_method', 'auto' );
+		$color_method = get_option( 'leira_letter_avatar_color_method', 'auto' );
 		$color_method = $this->sanitize->color_method( $color_method );
 		//By default, find the best contrast color for the background
 		$color = $this->get_contrast_color( $bg );
 		if ( $color_method == 'fixed' ) {
-			$color = get_network_option( null, 'leira_letter_avatar_color', 'ffffff' );
+			$color = get_option( 'leira_letter_avatar_color', 'ffffff' );
 		}
 		$color = trim( trim( $color ), '#' );
 		$color = $this->sanitize->background( $color );


### PR DESCRIPTION
Hi,

I ran into the same issue reported here:
https://wordpress.org/support/topic/custom-setting-not-work/

When Multisite is enabled, the plugin settings would not persist — saving them did nothing, and the settings page always reloaded with defaults.

These options appear to be site-specific (the settings UI is per-site, even when the plugin is network-activated). So the settings should use the per-site options API.

This PR updates all instances of:

- get_network_option() → get_option()
- update_network_option() → update_option()

After this change, settings save and load correctly on each site in a Multisite network.

This should not break any existing installs because on single-site WordPress, get_network_option() already falls back to get_option(), so any previously saved values are still read correctly.

Thanks for the great plugin — hope this helps fix the Multisite issue!